### PR TITLE
Add support for multple errors returned

### DIFF
--- a/lib/canadapost.js
+++ b/lib/canadapost.js
@@ -100,6 +100,12 @@ class CanadaPostClient {
 
     // We got a response, but Canada Post indicates an error
     if (result && result.messages && result.messages.message) {
+      // If there is an array of errors, return those
+      if (Array.isArray(result.messages.message)) {
+        const messages = result.messages.message.map(err => `${err.description} - (code ${err.code})`).join('\n');
+        const codes = result.messages.message.map(err => err.code);
+        throw new CanadaPostError(messages, codes);
+      }
       throw new CanadaPostError(result.messages.message.description, result.messages.message.code);
     }
 


### PR DESCRIPTION
thanks for the lib! 

Looks like canada post will return an array of errors if multiple things are wrong. Currently it just swallows that error.

